### PR TITLE
feat: add specific api-auth for signIn routes

### DIFF
--- a/middlewares/api-auth.js
+++ b/middlewares/api-auth.js
@@ -10,6 +10,17 @@ const authenticated = (req, res, next) => {
     next()
   })(req, res, next)
 }
+
+const signinRoleUser = (req, res, next) => {
+  if (helpers.getUser(req)?.role === 'user') return next()
+  throw new Error('account not exist')
+}
+
+const signinRoleAdmin = (req, res, next) => {
+  if (helpers.getUser(req)?.role === 'admin') return next()
+  throw new Error('account not exist')
+}
+
 const authenticateUser = (req, res, next) => {
   if (helpers.getUser(req)?.role === 'user') return next()
   return res.status(403).json({ status: 'error', message: 'permission denied' })
@@ -21,6 +32,8 @@ const authenticateAdmin = (req, res, next) => {
 
 module.exports = {
   authenticated,
+  signinRoleUser,
+  signinRoleAdmin,
   authenticateUser,
   authenticateAdmin
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -11,20 +11,20 @@ const tweets = require('./modules/tweets')
 const followships = require('./modules/followships')
 const passport = require('../config/passport')
 
-const { authenticated, authenticateUser, authenticateAdmin } = require('../middlewares/api-auth')
+const { authenticated, signinRoleUser, signinRoleAdmin, authenticateUser, authenticateAdmin } = require('../middlewares/api-auth')
 const { apiErrorHandler } = require('../middlewares/error-handler')
 
 router.get('/test', APItestController.getTestJSON)
 router.post(
   '/admin/signin',
   passport.authenticate('local', { session: false }),
-  authenticateAdmin,
+  signinRoleAdmin,
   adminController.signIn
 )
 router.post(
   '/users/signin',
   passport.authenticate('local', { session: false }),
-  authenticateUser,
+  signinRoleUser,
   userController.signIn
 )
 router.post('/users', userController.signUp)


### PR DESCRIPTION
For better security, add specific api-auth for signIn routes shows message "account not exist" while passing LocalStrategy but role is not correct.